### PR TITLE
Improve transaction and balance request reliability

### DIFF
--- a/src/lunch-flow-client.ts
+++ b/src/lunch-flow-client.ts
@@ -1,9 +1,10 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, AxiosError } from 'axios';
 import { LunchFlowTransaction, LunchFlowAccount, LunchFlowAccountId } from './types';
 
 export class LunchFlowClient {
   private client: AxiosInstance;
   private apiKey: string;
+  private readonly maxRetries: number = 3;
 
   constructor(apiKey: string, baseUrl: string = 'https://api.lunchflow.com') {
     this.apiKey = apiKey;
@@ -13,23 +14,75 @@ export class LunchFlowClient {
         'x-api-key': apiKey,
         'Content-Type': 'application/json',
       },
-      timeout: 10000,
+      timeout: 60000,
     });
+  }
+
+  private async retryWithBackoff<T>(
+    operation: () => Promise<T>,
+    operationName: string,
+    retryCount: number = 0
+  ): Promise<T> {
+    try {
+      return await operation();
+    } catch (error: any) {
+      const isRetriableError = this.isRetriableError(error);
+      
+      if (retryCount < this.maxRetries && isRetriableError) {
+        const backoffDelay = Math.pow(2, retryCount) * 1000; // Exponential backoff: 1s, 2s, 4s
+        console.log(`${operationName} failed (attempt ${retryCount + 1}/${this.maxRetries + 1}). Retrying in ${backoffDelay}ms...`);
+        console.log(`Error: ${error.message}`);
+        
+        await this.sleep(backoffDelay);
+        return this.retryWithBackoff(operation, operationName, retryCount + 1);
+      }
+      
+      // Log final failure
+      if (retryCount >= this.maxRetries) {
+        console.error(`${operationName} failed after ${this.maxRetries + 1} attempts. Final error: ${error.message}`);
+      }
+      
+      throw error;
+    }
+  }
+
+  private isRetriableError(error: any): boolean {
+    // Retry on network errors, timeouts, and 5xx server errors
+    if (error.code === 'ECONNRESET' || error.code === 'ETIMEDOUT' || error.code === 'ENOTFOUND') {
+      return true;
+    }
+    
+    if (error.response?.status >= 500) {
+      return true;
+    }
+    
+    // Retry on timeout errors
+    if (error.code === 'ECONNABORTED' && error.message.includes('timeout')) {
+      return true;
+    }
+    
+    return false;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   async testConnection(): Promise<boolean> {
     try {
-      // Try to get accounts as a health check
-      const response = await this.client.get('/accounts');
-      return response.status === 200;
+      return await this.retryWithBackoff(async () => {
+        // Try to get accounts as a health check
+        const response = await this.client.get('/accounts');
+        return response.status === 200;
+      }, 'Test Lunch Flow connection');
     } catch (error: any) {
-      console.error('Lunch Flow connection test failed:', error.message);
+      console.error('Lunch Flow connection test failed after all retries:', error.message);
       return false;
     }
   }
 
   async getAccounts(): Promise<LunchFlowAccount[]> {
-    try {
+    return this.retryWithBackoff(async () => {
       const response = await this.client.get('/accounts');
       
       // Handle different possible response structures
@@ -39,14 +92,11 @@ export class LunchFlowClient {
         console.warn('Unexpected response structure from Lunch Flow accounts endpoint');
         return [];
       }
-    } catch (error: any) {
-      console.error('Failed to fetch Lunch Flow accounts:', error.message);
-      throw new Error(`Failed to fetch accounts: ${error.message}`);
-    }
+    }, 'Fetch Lunch Flow accounts');
   }
 
   async getTransactions(accountId: LunchFlowAccountId): Promise<LunchFlowTransaction[]> {
-    try {
+    return this.retryWithBackoff(async () => {
       const response = await this.client.get(`/accounts/${accountId}/transactions`);
       
       // Handle different possible response structures
@@ -56,9 +106,6 @@ export class LunchFlowClient {
         console.warn('Unexpected response structure from Lunch Flow transactions endpoint');
         return [];
       }
-    } catch (error: any) {
-      console.error('Failed to fetch Lunch Flow transactions:', error.message);
-      throw new Error(`Failed to fetch transactions: ${error.message}`);
-    }
+    }, `Fetch transactions for account ${accountId}`);
   }
 }


### PR DESCRIPTION
Increase API request timeout to 60 seconds and add up to 3 retries with exponential backoff to improve reliability for transaction and balance requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac5c372d-41c4-4683-88b9-4f04ac5d3830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac5c372d-41c4-4683-88b9-4f04ac5d3830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

