### PR TITLE
Add a config option for duplicate checking across all accounts

### DIFF
--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -56,6 +56,7 @@ export class ConfigManager {
         budgetSyncId: '',
         password: '',
         encryptionPassword: undefined,
+        duplicateCheckingAcrossAccounts: false, // Default to off
       },
       accountMappings: [],
     };
@@ -67,9 +68,15 @@ export class ConfigManager {
     this.saveConfig(config);
   }
 
-  updateActualBudgetConfig(serverUrl: string, budgetSyncId: string, serverPassword: string, encryptionPassword?: string): void {
+  updateActualBudgetConfig(serverUrl: string, budgetSyncId: string, serverPassword: string, encryptionPassword?: string, duplicateCheckingAcrossAccounts?: boolean): void {
     const config = this.loadConfig() || this.createDefaultConfig();
-    config.actualBudget = { serverUrl, budgetSyncId, password: serverPassword, encryptionPassword };
+    config.actualBudget = { 
+      serverUrl, 
+      budgetSyncId, 
+      password: serverPassword, 
+      encryptionPassword,
+      duplicateCheckingAcrossAccounts: duplicateCheckingAcrossAccounts ?? config.actualBudget.duplicateCheckingAcrossAccounts ?? false
+    };
     this.saveConfig(config);
   }
 
@@ -93,6 +100,7 @@ export class ConfigManager {
       typeof config.actualBudget.budgetSyncId === 'string' &&
       typeof config.actualBudget.password === 'string' &&
       (typeof config.actualBudget.encryptionPassword === 'string' || config.actualBudget.encryptionPassword === undefined) &&
+      (typeof config.actualBudget.duplicateCheckingAcrossAccounts === 'boolean' || config.actualBudget.duplicateCheckingAcrossAccounts === undefined) &&
       Array.isArray(config.accountMappings)
     );
   }

--- a/src/duplicate-detector.ts
+++ b/src/duplicate-detector.ts
@@ -1,0 +1,68 @@
+import { ActualBudgetTransaction } from './types';
+
+export interface DuplicateInfo {
+  isDuplicate: boolean;
+  duplicateOf?: string;
+  existingTransaction?: ActualBudgetTransaction;
+}
+
+export class DuplicateTransactionDetector {
+  private existingTransactions: Map<string, ActualBudgetTransaction> = new Map();
+
+  constructor(existingTransactions: ActualBudgetTransaction[] = []) {
+    this.buildTransactionMap(existingTransactions);
+  }
+
+  private buildTransactionMap(transactions: ActualBudgetTransaction[]): void {
+    this.existingTransactions.clear();
+    
+    for (const transaction of transactions) {
+      // Use imported_id as the primary key for duplicate detection
+      if (transaction.imported_id) {
+        this.existingTransactions.set(transaction.imported_id, transaction);
+      }
+    }
+  }
+
+  checkForDuplicates(newTransactions: ActualBudgetTransaction[]): ActualBudgetTransaction[] {
+    return newTransactions.map(transaction => {
+      const duplicateInfo = this.checkTransaction(transaction);
+      
+      return {
+        ...transaction,
+        isDuplicate: duplicateInfo.isDuplicate,
+        duplicateOf: duplicateInfo.duplicateOf,
+      };
+    });
+  }
+
+  private checkTransaction(transaction: ActualBudgetTransaction): DuplicateInfo {
+    if (!transaction.imported_id) {
+      return { isDuplicate: false };
+    }
+
+    const existingTransaction = this.existingTransactions.get(transaction.imported_id);
+    
+    if (existingTransaction) {
+      return {
+        isDuplicate: true,
+        duplicateOf: existingTransaction.id,
+        existingTransaction,
+      };
+    }
+
+    return { isDuplicate: false };
+  }
+
+  getDuplicateCount(transactions: ActualBudgetTransaction[]): number {
+    return transactions.filter(t => t.isDuplicate).length;
+  }
+
+  getUniqueTransactions(transactions: ActualBudgetTransaction[]): ActualBudgetTransaction[] {
+    return transactions.filter(t => !t.isDuplicate);
+  }
+
+  getDuplicateTransactions(transactions: ActualBudgetTransaction[]): ActualBudgetTransaction[] {
+    return transactions.filter(t => t.isDuplicate);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export interface ActualBudgetTransaction {
   cleared?: boolean;
   notes?: string;
   imported_id?: string;
+  isDuplicate?: boolean;
+  duplicateOf?: string; // ID of the existing transaction this duplicates
 }
 
 export interface ActualBudgetAccount {
@@ -53,6 +55,7 @@ export interface Config {
     budgetSyncId: string;
     password: string; // Server password (backward compatible)
     encryptionPassword?: string; // Optional password for end-to-end encryption
+    duplicateCheckingAcrossAccounts?: boolean; // Check for duplicate transactions across all accounts before import
   };
   accountMappings: AccountMapping[];
 }


### PR DESCRIPTION
The use case here is if the rules reassign the transactions to a different account, running the import again would create duplicates.

This is needed for Monzo pots for example, as while pots have separate accounts, transactions from the pots show up as happening from the main account.

Here's the thought process:
<img width="1426" height="302" alt="image" src="https://github.com/user-attachments/assets/efcc9710-7864-47ba-85fb-5170c1cda081" />
