### PR TITLE
Preserve existing account mappings in interactive config

### DIFF
--- a/src/importer.ts
+++ b/src/importer.ts
@@ -112,7 +112,8 @@ export class LunchFlowImporter {
       await this.ui.showAccountsTable(lfAccounts, '📡 Lunch Flow Accounts');
       await this.ui.showAccountsTable(abAccounts, '💰 Actual Budget Accounts');
 
-      const mappings = await this.ui.configureAccountMappings(lfAccounts, abAccounts);
+      const existingMappings = this.config?.accountMappings ?? [];
+      const mappings = await this.ui.configureAccountMappings(lfAccounts, abAccounts, existingMappings);
       
       if (this.config) {
         this.config.accountMappings = mappings;


### PR DESCRIPTION
I noticed that when rerunning the interactive account mapping tool, it blew away all existing mapping information. This PR updates the process so it lets the user choose whether to keep the existing mapping, edit it, or delete it. If the user decides to edit it, the current values are used as defaults.