### PR TITLE
Add an env variable to control verbosity of Actual Budget logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ You can configure a sync start date for each account mapping to control which tr
 
 | Variable | Description |
 |---|---|
-| `ACTUAL_BUDGET_VERBOSE` | Set to any value to print verbose debug output from the Actual Budget API during import (e.g. transaction reconciliation data). Off by default. |
+| `ACTUAL_BUDGET_VERBOSE` | Set to `0` to suppress verbose debug output from the Actual Budget API during import (e.g. transaction reconciliation data). On by default. |
 
 Example:
 ```bash
-ACTUAL_BUDGET_VERBOSE=1 actual-flow import
+ACTUAL_BUDGET_VERBOSE=0 actual-flow import
 ```
 
 ## Automation Examples

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ You can configure a sync start date for each account mapping to control which tr
 3. Shows transaction preview and processing summary
 4. Respects configured sync start dates for each account
 
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `ACTUAL_BUDGET_VERBOSE` | Set to any value to print verbose debug output from the Actual Budget API during import (e.g. transaction reconciliation data). Off by default. |
+
+Example:
+```bash
+ACTUAL_BUDGET_VERBOSE=1 actual-flow import
+```
+
 ## Automation Examples
 
 ### Cron Job

--- a/src/actual-budget-client.ts
+++ b/src/actual-budget-client.ts
@@ -3,7 +3,7 @@ import { ActualBudgetTransaction, ActualBudgetAccount } from './types';
 import fs from 'fs';
 import path from 'path';
 
-const verbose = Boolean(process.env.ACTUAL_BUDGET_VERBOSE);
+const verbose = process.env.ACTUAL_BUDGET_VERBOSE !== '0';
 
 export class ActualBudgetClient {
   private serverUrl: string;

--- a/src/actual-budget-client.ts
+++ b/src/actual-budget-client.ts
@@ -3,6 +3,8 @@ import { ActualBudgetTransaction, ActualBudgetAccount } from './types';
 import fs from 'fs';
 import path from 'path';
 
+const verbose = Boolean(process.env.ACTUAL_BUDGET_VERBOSE);
+
 export class ActualBudgetClient {
   private serverUrl: string;
   private budgetSyncId: string;
@@ -30,6 +32,7 @@ export class ActualBudgetClient {
         dataDir: this.dataDir,
         serverURL: this.serverUrl,
         password: this.serverPassword,
+        verbose,
       });
       
       // Download the budget to local cache with encryption support
@@ -186,6 +189,7 @@ export class ActualBudgetClient {
         dataDir: this.dataDir,
         serverURL: this.serverUrl,
         password: this.serverPassword,
+        verbose,
       });
       
       const budgets = await actualAPI.getBudgets();


### PR DESCRIPTION
The Actual Budget library generates a lot of noise in its output, e.g.:

```
> Performing transaction reconciliation
> Performing transaction reconciliation matching
> Debug data for the operations: {
>   transactionsStep1: [
>     {
>       payee_name: 'Ia364.58',
>       trans: [Object],
>       subtransactions: null,
>       match: [Object],
>       fuzzyDataset: null
>     },
>     {
>       payee_name: 'Ia-364.58',
>       trans: [Object],
>       subtransactions: null,
>       match: [Object],
>       fuzzyDataset: null
>     },
```

This PR makes it configurable: setting `ACTUAL_BUDGET_VERBOSE` env var to `0` suppresses the logs.

Verbose mode is on by default to preserve existing behavior.